### PR TITLE
implement asynchronous cancellation

### DIFF
--- a/platform/vita/Makefile
+++ b/platform/vita/Makefile
@@ -166,7 +166,7 @@ CC = arm-vita-eabi-gcc
 CXX = arm-vita-eabi-g++
 AR = arm-vita-eabi-ar
 
-CFLAGS = $(GLOBAL_CFLAGS) -fPIC -Wl,-q -Wall -O3 -ffat-lto-objects -flto -fno-strict-aliasing -I. -I../.. -I../helper
+CFLAGS = $(GLOBAL_CFLAGS) -fPIC -Wl,-q -Wall -O3 -ffat-lto-objects -flto -fno-strict-aliasing -I. -I../.. -I../helper -DPTE_SUPPORT_ASYNC_CANCEL
 CXXFLAGS = $(CFLAGS) -fexceptions -fno-rtti -Werror -DPTE_CLEANUP_CXX
 ASFLAGS = $(CFLAGS)
 

--- a/platform/vita/Makefile
+++ b/platform/vita/Makefile
@@ -167,7 +167,7 @@ CXX = arm-vita-eabi-g++
 AR = arm-vita-eabi-ar
 
 CFLAGS = $(GLOBAL_CFLAGS) -fPIC -Wl,-q -Wall -O3 -ffat-lto-objects -flto -fno-strict-aliasing -I. -I../.. -I../helper -DPTE_SUPPORT_ASYNC_CANCEL
-CXXFLAGS = $(CFLAGS) -fexceptions -fno-rtti -Werror -DPTE_CLEANUP_CXX
+CXXFLAGS = $(CFLAGS) -fexceptions -fno-rtti -Werror
 ASFLAGS = $(CFLAGS)
 
 ifeq ($(CLEANUP_TYPE),CPP)

--- a/platform/vita/Makefile.tests
+++ b/platform/vita/Makefile.tests
@@ -177,7 +177,7 @@ AR = arm-vita-eabi-ar
 
 
 INCDIR = 
-CFLAGS = $(GLOBAL_CFLAGS) -fPIC -O2 -Wall -g -I.. -I. -fno-strict-aliasing  -I../..
+CFLAGS = $(GLOBAL_CFLAGS) -fPIC -O2 -Wall -g -I.. -I. -fno-strict-aliasing  -I../.. -DPTE_SUPPORT_ASYNC_CANCEL
 CXXFLAGS = $(CFLAGS) -fexceptions -fno-rtti
 ASFLAGS = $(CFLAGS)
 

--- a/platform/vita/vita_osal.c
+++ b/platform/vita/vita_osal.c
@@ -161,6 +161,13 @@ int pte_osThreadGetDefaultPriority()
     return 160;
 }
 
+#ifdef PTE_SUPPORT_ASYNC_CANCEL
+pte_osResult PSP2CLDR_STUB pte_osThreadAsyncCancel(pte_osThreadHandle threadHandle, void (*handlerFunction)(unsigned int), unsigned int arg)
+{
+    UDF_TRAP;
+}
+#endif
+
 /****************************************************************************
  *
  * Mutexes

--- a/pte_generic_osal.h
+++ b/pte_generic_osal.h
@@ -242,6 +242,21 @@ int pte_osThreadGetMinPriority();
  */
 int pte_osThreadGetDefaultPriority();
 
+#ifdef PTE_SUPPORT_ASYNC_CANCEL
+/**
+ * Asynchronously cancel the specified thread.
+ *
+ * @param threadHandle handle of thread to check the state of.
+ * @param handlerFunction target thread's control should be transferred to handlerFunction
+ * @param arg argument to the handler function
+ *
+ * @return PTE_OS_OK - cancellation request has been queued successfully
+ * @return PTE_OS_INVALID_PARAM - the specified thread handle is invalid
+ * @return PTE_OS_GENERAL_FAILURE - operation not supported, EPERM will be returned
+ */
+pte_osResult pte_osThreadAsyncCancel(pte_osThreadHandle threadHandle, void (*handlerFunction)(unsigned int), unsigned int arg);
+#endif
+
 //@}
 
 

--- a/pte_throw.c
+++ b/pte_throw.c
@@ -90,7 +90,7 @@ pte_throw (unsigned int exception)
         }
 
       pte_thread_detach_and_exit_np ();
-
+      (void)exitCode;
 //      pte_osThreadExit((void*)exitCode);
 
     }

--- a/pthread_cancel.c
+++ b/pthread_cancel.c
@@ -141,10 +141,25 @@ pthread_cancel (pthread_t thread)
            * Note that most of the async cancellation code is still in here if anyone
            * wanted to add the OS/platform specific stuff.
            */
-          (void) pthread_mutex_unlock (&tp->cancelLock);
-
+#ifdef PTE_SUPPORT_ASYNC_CANCEL
+          pte_osResult cancelStatus;
+          cancelStatus = pte_osThreadAsyncCancel(tp->threadId, &pte_throw, PTE_EPS_CANCEL);
+          if (cancelStatus == PTE_OS_OK)
+          {
+            result = 0;
+          }
+          else if (cancelStatus == PTE_OS_INVALID_PARAM)
+          {
+            result = ESRCH;
+          }
+          else
+          {
+            result = EPERM;
+          }
+#else
           result = EPERM;
-
+#endif
+          (void) pthread_mutex_unlock (&tp->cancelLock);
         }
     }
   else

--- a/tests/cancel6a.c
+++ b/tests/cancel6a.c
@@ -141,7 +141,8 @@ int pthread_test_cancel6a()
   for (i = 1; i <= NUMTHREADS; i++)
     {
       assert(pthread_cancel(t[i]) == 0);
-      assert(pthread_cancel(t[i]) == ESRCH);
+      // the standard does not return an error in this case
+      assert(pthread_cancel(t[i]) == 0);
     }
 
   /*

--- a/tests/cleanup0.c
+++ b/tests/cleanup0.c
@@ -150,6 +150,8 @@ int pthread_test_cleanup0()
   int i;
   pthread_t t[NUMTHREADS + 1];
 
+  pop_count.i = 0;
+  pop_count.null = 0;
   pte_osMutexCreate(&pop_count.cs);
 
   assert((t[0] = pthread_self()) != NULL);

--- a/tests/cleanup1.c
+++ b/tests/cleanup1.c
@@ -160,6 +160,8 @@ int pthread_test_cleanup1()
   int i;
   pthread_t t[NUMTHREADS + 1];
 
+  pop_count.i = 0;
+  pop_count.null = 0;
   pte_osMutexCreate(&pop_count.cs);
 
   assert((t[0] = pthread_self()) != NULL);

--- a/tests/cleanup2.c
+++ b/tests/cleanup2.c
@@ -145,6 +145,8 @@ int pthread_test_cleanup2()
   int i;
   pthread_t t[NUMTHREADS + 1];
 
+  pop_count.i = 0;
+  pop_count.null = 0;
   pte_osMutexCreate(&pop_count.cs);
 
   assert((t[0] = pthread_self()) != NULL);

--- a/tests/cleanup3.c
+++ b/tests/cleanup3.c
@@ -156,6 +156,8 @@ int pthread_test_cleanup3()
   int i;
   pthread_t t[NUMTHREADS + 1];
 
+  pop_count.i = 0;
+  pop_count.null = 0;
   pte_osMutexCreate(&pop_count.cs);
 
   assert((t[0] = pthread_self()) != NULL);


### PR DESCRIPTION
- enable PTE_SUPPORT_ASYNC_CANCEL
- disable PTE_CLEANUP_CXX until we enable it for everything
- tests: fix cleanup tests for re-runs
- tests: cancal6a fix non-standard use of ESRCH